### PR TITLE
Add event handlers to options.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -100,7 +100,7 @@ function runMochaSimply() {
         .src(config.test.base + config.test.pattern, {read: false})
         .pipe(mocha({
             ui: 'tdd',
-            reporter: 'dot',
+            reporter: 'spec',
             require: ['babel-core/polyfill']
         }))
         .on('error', gutil.log);

--- a/index.js
+++ b/index.js
@@ -44,21 +44,10 @@ function empower (assert, options) {
     return enhancedAssert;
 }
 
-function onError (ev) {
-    var e = ev.error;
-    var message = ev.originalMessage;
-    var context = ev.powerAssertContext;
-    if (e.name !== 'AssertionError') {
-        throw e;
-    }
-    e.powerAssertContext = context;
-    throw e;
-};
-
 function empowerAssertObject (assertObject, options) {
     var config = extend(defaultOptions(), options);
     var target = config.destructive ? assertObject : create(assertObject);
-    var decorator = new Decorator(target, onError, config);
+    var decorator = new Decorator(target, config);
     return extend(target, decorator.enhancement());
 }
 
@@ -67,7 +56,7 @@ function empowerAssertFunction (assertFunction, options) {
     if (config.destructive) {
         throw new Error('cannot use destructive:true to function.');
     }
-    var decorator = new Decorator(assertFunction, onError, config);
+    var decorator = new Decorator(assertFunction, config);
     var enhancement = decorator.enhancement();
     var powerAssert;
     if (typeof enhancement === 'function') {

--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@
  * Licensed under the MIT license.
  *   https://github.com/power-assert-js/empower/blob/master/MIT-LICENSE.txt
  */
+var create = require('core-js/library/fn/object/create');
+var extend = require('xtend/mutable');
 var defaultOptions = require('./lib/default-options');
 var Decorator = require('./lib/decorator');
 var capturable = require('./lib/capturable');
-var create = require('object-create');
+var define = require('./lib/define-properties');
 var slice = Array.prototype.slice;
-var extend = require('xtend/mutable');
-var define = require('define-properties');
 
 /**
  * Enhance Power Assert feature to assert function/object.

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -10,9 +10,23 @@ function decorate (callSpec, decorator) {
     var numArgsToCapture = callSpec.numArgsToCapture;
 
     return function decoratedAssert () {
-        var context, message, args = slice.apply(arguments);
+        var context, message, hasMessage = false, args = slice.apply(arguments);
+
+        if (numArgsToCapture === (args.length - 1)) {
+            message = args.pop();
+            hasMessage = true;
+        }
+
+        var invocation = {
+            thisObj: thisObj,
+            func: func,
+            values: args,
+            message: message,
+            hasMessage: hasMessage
+        };
+
         if (some(args, isCaptured)) {
-            var values = map(args.slice(0, numArgsToCapture), function (arg) {
+            invocation.values = map(args.slice(0, numArgsToCapture), function (arg) {
                 if (isNotCaptured(arg)) {
                     return arg;
                 }
@@ -29,19 +43,9 @@ function decorate (callSpec, decorator) {
                 return arg.powerAssertContext.value;
             });
 
-            if (numArgsToCapture === (args.length - 1)) {
-                message = args[args.length - 1];
-            }
-
-            var invocation = {
-                thisObj: thisObj,
-                func: func,
-                values: values,
-                message: message
-            };
             return decorator.concreteAssert(invocation, context);
         } else {
-            return func.apply(thisObj, args);
+            return decorator.fallbackAssert(invocation);
         }
     };
 }

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -1,8 +1,8 @@
 'use strict';
 
+var some = require('core-js/library/fn/array/some');
+var map = require('core-js/library/fn/array/map');
 var slice = Array.prototype.slice;
-var map = require('array-map');
-var some = require('array-some');
 
 function decorate (callSpec, decorator) {
     var func = callSpec.func;

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -1,19 +1,18 @@
 'use strict';
 
 var signature = require('call-signature');
-var extend = require('xtend/mutable');
 var forEach = require('array-foreach');
 var map = require('array-map');
 var filter = require('array-filter');
 var decorate = require('./decorate');
 
 
-function Decorator (receiver, onError, config) {
+function Decorator (receiver, config) {
     this.receiver = receiver;
     this.config = config;
-    this.onError = onError;
+    this.onError = config.onError;
+    this.onSuccess = config.onSuccess;
     this.signatures = map(config.patterns, signature.parse);
-    this.eagerEvaluation = !(config.modifyMessageOnRethrow || config.saveContextOnRethrow);
 }
 
 Decorator.prototype.enhancement = function () {
@@ -54,11 +53,28 @@ Decorator.prototype.concreteAssert = function (invocation, context) {
     var thisObj = invocation.thisObj;
     var args = invocation.values;
     var message = invocation.message;
+    var ret;
     try {
-        return func.apply(thisObj, args.concat(message));
+        ret = func.apply(thisObj, args.concat(message));
     } catch (e) {
-        this.onError({error: e, originalMessage: message, powerAssertContext: context});
+        return this.onError({error: e, originalMessage: message, powerAssertContext: context});
     }
+    return this.onSuccess({returnValue: ret, originalMessage: message, powerAssertContext: context});
+};
+
+Decorator.prototype.fallbackAssert = function (invocation) {
+    var func = invocation.func;
+    var thisObj = invocation.thisObj;
+    var args = invocation.values;
+    var message = invocation.message;
+    args = args.concat(message);
+    var ret;
+    try {
+        ret = func.apply(thisObj, args);
+    } catch (e) {
+        return this.onError({error: e, originalMessage: message, args: args});
+    }
+    return this.onSuccess({returnValue: ret, originalMessage: message, args: args});
 };
 
 function numberOfArgumentsToCapture (matcher) {

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -1,9 +1,9 @@
 'use strict';
 
+var forEach = require('core-js/library/fn/array/for-each');
+var filter = require('core-js/library/fn/array/filter');
+var map = require('core-js/library/fn/array/map');
 var signature = require('call-signature');
-var forEach = require('array-foreach');
-var map = require('array-map');
-var filter = require('array-filter');
 var decorate = require('./decorate');
 
 

--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -3,8 +3,8 @@
 module.exports = function defaultOptions () {
     return {
         destructive: false,
-        modifyMessageOnRethrow: false,
-        saveContextOnRethrow: true,
+        onError: onError,
+        onSuccess: onSuccess,
         patterns: [
             'assert(value, [message])',
             'assert.ok(value, [message])',
@@ -19,3 +19,15 @@ module.exports = function defaultOptions () {
         ]
     };
 };
+
+function onError (errorEvent) {
+    var e = errorEvent.error;
+    if (errorEvent.powerAssertContext && e.name === 'AssertionError') {
+        e.powerAssertContext = errorEvent.powerAssertContext;
+    }
+    throw e;
+}
+
+function onSuccess(successEvent) {
+    return successEvent.returnValue;
+}

--- a/lib/define-properties.js
+++ b/lib/define-properties.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var defineProperty = require('core-js/library/fn/object/define-property');
+var foreach = require('core-js/library/fn/array/for-each');
+var keys = require('core-js/library/fn/object/keys');
+
+var defineProperties = function (object, map) {
+  var props = keys(map);
+  foreach(props, function (name) {
+    defineProperty(object, name, {
+      configurable: true,
+      enumerable: false,
+      value: map[name],
+      writable: true
+    });
+  });
+};
+
+module.exports = defineProperties;

--- a/package.json
+++ b/package.json
@@ -17,13 +17,8 @@
     }
   ],
   "dependencies": {
-    "array-filter": "^1.0.0",
-    "array-foreach": "^1.0.1",
-    "array-map": "0.0.0",
-    "array-some": "^1.0.0",
     "call-signature": "0.0.2",
-    "define-properties": "^1.1.2",
-    "object-create": "^0.1.0",
+    "core-js": "^1.2.6",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/test/empower_option_test.js
+++ b/test/empower_option_test.js
@@ -19,14 +19,9 @@ suite('empower.defaultOptions()', function () {
     test('destructive: false', function () {
         assert.equal(this.options.destructive, false);
     });
-    test('modifyMessageOnRethrow: false', function () {
-        assert.equal(this.options.modifyMessageOnRethrow, false);
-    });
-    test('saveContextOnRethrow: true', function () {
-        assert.equal(this.options.saveContextOnRethrow, true);
-    });
-    test('formatter: undefined', function () {
-        assert.deepEqual(typeof this.options.formatter, 'undefined');
+    test('onError: function', function () {
+        assert.equal(typeof this.options.onError, 'function');
+        assert.equal(typeof this.options.onSuccess, 'function');
     });
     test('patterns: Array', function () {
         assert.deepEqual(this.options.patterns, [

--- a/test/not_espowered_case_test.js
+++ b/test/not_espowered_case_test.js
@@ -12,16 +12,11 @@
     baseAssert
 ) {
 
-function fakeFormatter (context) {
-    throw new Error('formatter should not be called');
-}
+suite('not-espowered: ', function () {
 
+var assert = empower(baseAssert);
 
-function testWithOption (option) {
-    var assert = empower(baseAssert, fakeFormatter, option);
-
-
-test(JSON.stringify(option) + ' argument is null Literal.', function () {
+test('argument is null Literal.', function () {
     var foo = 'foo';
     try {
         eval('assert.equal(foo, null);');
@@ -34,7 +29,7 @@ test(JSON.stringify(option) + ' argument is null Literal.', function () {
 });
 
 
-test(JSON.stringify(option) + ' empowered function also acts like an assert function', function () {
+test('empowered function also acts like an assert function', function () {
     var falsy = 0;
     try {
         eval('assert(falsy);');
@@ -47,7 +42,7 @@ test(JSON.stringify(option) + ' empowered function also acts like an assert func
 });
 
 
-suite(JSON.stringify(option) + ' assertion method with one argument', function () {
+suite('assertion method with one argument', function () {
     test('Identifier', function () {
         var falsy = 0;
         try {
@@ -62,7 +57,7 @@ suite(JSON.stringify(option) + ' assertion method with one argument', function (
 });
 
 
-suite(JSON.stringify(option) + ' assertion method with two arguments', function () {
+suite('assertion method with two arguments', function () {
     test('both Identifier', function () {
         var foo = 'foo', bar = 'bar';
         try {
@@ -100,26 +95,6 @@ suite(JSON.stringify(option) + ' assertion method with two arguments', function 
     });
 });
 
-}
-
-testWithOption({
-    modifyMessageOnRethrow: false,
-    saveContextOnRethrow: false
-});
-
-testWithOption({
-    modifyMessageOnRethrow: true,
-    saveContextOnRethrow: false
-});
-
-testWithOption({
-    modifyMessageOnRethrow: false,
-    saveContextOnRethrow: true
-});
-
-testWithOption({
-    modifyMessageOnRethrow: true,
-    saveContextOnRethrow: true
 });
 
 }));


### PR DESCRIPTION
This moves the `onError` handler into options, and introduces an `onSuccess` handler.
Sensible defaults for both are provided in `default-options`.

This will be really handy for AVA, since we track both successfull and failed assertions
for comparison against the plan count.

Both handlers are invoked outside of a try/catch block, so either can elect to throw,
and the error will not be intercepted. (It is unlikely anyone would ever want to do
that in `onSuccess`, but it wouldn't be good for us to mask that error either).

I also dropped the `saveContextOnRethrow` and `modifyMessageOnRethrow` options entirely.
They were not being used anywhere in this module. The main `empower` module can wrap this
one and provide custon `onError` and `onSuccess` callbacks that are sensitive to those options.